### PR TITLE
change init procedure; pass args to callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ numbers, in which case the positioning is absolute, or `"left" / "right" /
 the position is calculated based on the screen geometry and the wibox size.
 
 Combining relative and absolute positioning is possible, so you can have a wibox
-on the bottom at 123px from the left with `set_location(123, "bottom).
+on the bottom at 123px from the left with `set_location(123, "bottom")`.
 
 For convenience, there are additional methods for setting an offset in addition
 to a relative position, `set_x_offset(amount)` / `set_y_offset(amount)`. The

--- a/init.lua
+++ b/init.lua
@@ -115,6 +115,10 @@ end
 
 local function show_box(s, map, name)
 	modewibox.screen = s
+	awful.screen.connect_for_each_screen(
+	function(s)
+		  if modewibox.screen ~= s then modewibox[s].visible = false end
+	end)
 	local label = "<big><b>" .. name .. "</b></big>"
 	if settings.show_options then
 		for _, mapping in ipairs(map) do
@@ -132,8 +136,10 @@ local function show_box(s, map, name)
 end
 
 local function hide_box()
-	local s = modewibox.screen
-	if s ~= nil then modewibox[s].visible = false end
+       local s = modewibox.screen
+       awful.screen.connect_for_each_screen(function(s)
+		modewibox[s].visible = false
+       end)
 end
 
 local function mapping_for(keymap, key)

--- a/init.lua
+++ b/init.lua
@@ -82,7 +82,7 @@ local function update_settings()
 end
 
 
-local function ensure_init()
+function modalbind.init()
 	awful.screen.connect_for_each_screen(function(s)
 		modewidget[s] = wibox.widget.textbox()
 		modewidget[s]:set_align("left")
@@ -151,21 +151,21 @@ local function close_box()
 	hide_box();
 end
 
-local function call_key_if_present(keymap, key)
+local function call_key_if_present(keymap, key, args)
 	local callback = mapping_for(keymap,key)
-	if callback then callback[2]() end
+	if callback then callback[2](args) end
 end
 
-function modalbind.grab(keymap, name, stay_in_mode)
+function modalbind.grab(keymap, name, stay_in_mode, args)
 	if name then
 		show_box(mouse.screen, keymap, name)
 		nesting = nesting + 1
 	end
-	call_key_if_present(keymap, "onOpen")
+	call_key_if_present(keymap, "onOpen", args)
 
 	keygrabber.run(function(mod, key, event)
 		if key == "Escape" then
-			call_key_if_present(keymap, "onClose")
+			call_key_if_present(keymap, "onClose", args)
 			close_box()
 			return true
 		end
@@ -175,7 +175,7 @@ function modalbind.grab(keymap, name, stay_in_mode)
 		mapping = mapping_for(keymap, key)
 		if mapping then
 			keygrabber.stop()
-			mapping[2]()
+			mapping[2](args)
 			if stay_in_mode then
 				modalbind.grab(keymap, name, true)
 			else
@@ -242,9 +242,9 @@ function modalbind.set_location(horizontal, vertical)
 	if (horizontal ~= "left" and horizontal ~= "right" and horizontal ~= "center" and type(horizontal) ~= "number") then
 		return
 	end
-	
+
 	settings.x_position = horizontal
-	settings.y_position = vertical 
+	settings.y_position = vertical
 end
 
 ---  enable displaying bindings for current mode
@@ -257,5 +257,4 @@ function modalbind.hide_options()
 	settings.show_options = false
 end
 
-ensure_init()
 return modalbind


### PR DESCRIPTION
Remove call to `ensure_init` function inside `init.lua`. Adding it under a name `init` to `modalbind` table.
Rationale: allow to keep all `require` calls at top of `rc.lua`. Initialize the module anywhere by calling `modalbind.init()`.  Right now `require("modalbind")` must be called after `beautiful.init(theme)`.

Allow to pass arguments to callback functions.
Rationale: additional arguments may be passed to callback functions. For example, `client` object is passed when in conext of a client window. It may be used like so:
```awful.key({ modkey }, "x", function(c) modalbind.grab(clientmap, "Client", false, c) end)```
Argument `c` is passed to `modalbind.grab` function and later may be used in binding table:
```{ "t", function (c) c.ontop = not c.ontop end, "Keep on top" }```