### PR TITLE
use declarative style, awful.placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,15 @@ The position and contents of the wibox can be configured:
 
 ### Positioning
 
-`modalbind.set_location(horizontal, vertical)` sets the location of the wibox
-displaying the mode and the bindings. `horizontal` and `vertical` can be
-numbers, in which case the positioning is absolute, or `"left" / "right" /
-"center"` (horizontal) `"top" / "bottom" / "center"` (vertical), in which case
-the position is calculated based on the screen geometry and the wibox size.
+`modalbind.set_location(position)` sets the location of the wibox
+displaying the mode and the bindings. Acceptable values of the `position`
+argument are `"top_left"`, `"top"`, `"top_right"` e.t.c. Full list of
+acceptable positions can be found
+[here](https://awesomewm.org/doc/api/libraries/awful.placement.html#align).
 
-Combining relative and absolute positioning is possible, so you can have a wibox
-on the bottom at 123px from the left with `set_location(123, "bottom")`.
-
-For convenience, there are additional methods for setting an offset in addition
-to a relative position, `set_x_offset(amount)` / `set_y_offset(amount)`. The
-wibox is moved the given amount of pixels *away from the border*, e.g. down for
-`top` but up for `bottom`. For `center` the box is moved right / down. The
-offsets are ignored, if the location was set to an absolute value.
+Additionally, location offset can be added via `set_x_offset(amount)` /
+`set_y_offset(amount)`. The wibox is moved the given amount of pixels to the
+*bottom right*. Negative offset values are allowed.
 
 ### Wibox style
 

--- a/init.lua
+++ b/init.lua
@@ -41,7 +41,10 @@ function modalbind.init()
 			width=1,
 			height=1,
 			opacity=defaults.opacity,
-			bg=beautiful.modebox_bg or "#000",
+			bg=beautiful.modebox_bg or
+				beautiful.bg_normal,
+			fg=beautiful.modebox_fg or
+				beautiful.fg_normal,
 			shape=gears.shape.round_rect,
 			type="toolbar"
 	})
@@ -57,8 +60,10 @@ function modalbind.init()
 				widget=wibox.widget.textbox
 			},
 			id="margin",
-			margins=beautiful.modebox_border_width or 5,
-			color=beautiful.modebox_border or "#000",
+			margins=beautiful.modebox_border_width or
+				beautiful.border_width,
+			color=beautiful.modebox_border or
+				beautiful.border_focus,
 			layout=wibox.container.margin,
 	})
 


### PR DESCRIPTION
Rewrote wibox using [declarative layout system](https://awesomewm.org/apidoc/documentation/03-declarative-layout.md.html). In my opinion it looks cleaner.

Manual placement was replaced by [awful.placement](https://awesomewm.org/doc/api/libraries/awful.placement.html#align). I find option `honor_workarea` particularly useful. It automatically takes into account position of the titlebar so that widget wont get drawn over it.

Cosmetic change - store references to the widget inside screen objects. 