### PR TITLE
add layout option; grab function parameters changed to named

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 modalbind allows you to create modal keybindings (similar to vim modes) in
 [awesome](https://awesomewm.org/). *modalbind requires awesome 4.0+*
 
-To use it, you define a table of bindings for a mode and create a normal binding
-to enter that mode. A mode table contains one table per binding, in the form
+To use it, you define a `keymap` table of bindings for a mode and
+create a normal binding to enter that mode. A `keymap` mode table contains one
+table per binding,in the form
 ```lua
 	{
 		key,        -- the key like for awful.key
@@ -19,11 +20,18 @@ the popup. Just add a table like the following:
   {"separator", group_title } -- literal string "separator" is required.
 ```
 
-Then, bind a key to `modalbind.grab(mapping_table, "Some Title")`, to open the mode menu. `modalbind.grab` takes up to four parameters:
-1. the mapping table
-2. the mode name. Optional, if not set, no box will be shown.
-3. "Stay in mode", boolean. If true, awesome will stay in the input mode until escape is pressed.
-4. additional arguments passed on to functions in the mapping table, e.g. passing the client for `clientkeys` bindings.
+Then, bind a key to `modalbind.grab{keymap=mapping_table, name="Some Title"}`,
+to open the mode menu. `modalbind.grab` takes up to five named parameters:
+1. `keymap` - the mapping table
+2. `name` - the mode name. Optional, if not set, no box will be shown.
+3. `stay_in_mode` - "Stay in mode" boolean. If true, awesome will stay in
+the input mode until escape is pressed. Defaults to `false`.
+4. `args` - additional arguments passed on to functions in the mapping table,
+e.g. passing the client for `clientkeys` bindings.
+5. `layout` - index of the layout, widget will automatically switch to. If two
+layouts are defined in the system (indexed 0 and 1), widget will switch to the
+chosen one upon entering input mode and restore previous layout,
+leaving it. When argument is not set, widget will not change the layout.
 
 An example mode for controlling mpd, entered by pressing <kbd>Mod</kbd> + <kbd>m</kbd>:
 
@@ -43,7 +51,7 @@ local modalbind = require("modalbind")
 modalbind.init()
 
 	...
-	awful.key({ modkey }, "m", function() modalbind.grab(mpdmap, "MPD", true) end),
+	awful.key({ modkey }, "m", function() modalbind.grab{keymap=mpdmap, name="MPD", stay_in_mode=true} end),
 	...
 ```
 
@@ -102,10 +110,12 @@ Theming is done via beautiful, the wibox uses default colors and the border
 color for focused windows. You can override this with these theme keys:
 
 ```lua
-theme.modebox_fg = "#AABBCC"     -- foreground
-theme.modebox_bg = "#DDEEFF"     -- background
-theme.modebox_border = "#112233" -- border color
-theme.modebox_border_width = 1   -- border width
+theme.modalbind_font = "Monospace 9" -- font
+theme.modebox_fg = "#AABBCC"         -- foreground
+theme.modebox_fg = "#AABBCC"         -- foreground
+theme.modebox_bg = "#DDEEFF"         -- background
+theme.modebox_border = "#112233"     -- border color
+theme.modebox_border_width = 1       -- border width
 ```
 
 You can change the opacity of the box with `modalbind.set_opacity(opacity)`,

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the popup. Just add a table like the following:
 ```
 
 Then, bind a key to `modalbind.grab{keymap=mapping_table, name="Some Title"}`,
-to open the mode menu. `modalbind.grab` takes up to five named parameters:
+to open the mode menu. `modalbind.grab` takes up to six named parameters:
 1. `keymap` - the mapping table
 2. `name` - the mode name. Optional, if not set, no box will be shown.
 3. `stay_in_mode` - "Stay in mode" boolean. If true, awesome will stay in
@@ -32,6 +32,7 @@ e.g. passing the client for `clientkeys` bindings.
 layouts are defined in the system (indexed 0 and 1), widget will switch to the
 chosen one upon entering input mode and restore previous layout,
 leaving it. When argument is not set, widget will not change the layout.
+6. `case_insensitive` - convert keys to lowercase befor matching.
 
 An example mode for controlling mpd, entered by pressing <kbd>Mod</kbd> + <kbd>m</kbd>:
 

--- a/init.lua
+++ b/init.lua
@@ -132,10 +132,16 @@ local function hide_box()
 	screen[1].modewibox.visible = false
 end
 
-local function mapping_for(keymap, key)
+local function mapping_for(keymap, key, use_lower)
+	local k = key
+	if use_lower then
+		k = k:lower()
+	end
 	for _, mapping in ipairs(keymap) do
-		local m = mapping[1]:lower()
-		local k = key:lower()
+		local m = mapping[1]
+		if use_lower then
+			m = m:lower()
+		end
 		if m == k or
 		(aliases[k] and m == k) then
 			return mapping
@@ -150,8 +156,8 @@ local function close_box()
 	hide_box();
 end
 
-local function call_key_if_present(keymap, key, args)
-	local callback = mapping_for(keymap,key)
+local function call_key_if_present(keymap, key, args, use_lower)
+	local callback = mapping_for(keymap,key, use_lower)
 	if callback then callback[2](args) end
 end
 
@@ -161,13 +167,14 @@ function modalbind.grab(options)
 	local stay_in_mode = options.stay_in_mode or false
 	local args = options.args
 	local layout = options.layout
+	local use_lower = options.case_insensitive or false
 
 	layout_swap(layout)
 	if name then
 		show_box(mouse.screen, keymap, name)
 		nesting = nesting + 1
 	end
-	call_key_if_present(keymap, "onOpen", args)
+	call_key_if_present(keymap, "onOpen", args, use_lower)
 
 	keygrabber.run(function(mod, key, event)
 		if key == "Escape" then
@@ -179,7 +186,7 @@ function modalbind.grab(options)
 
 		if event == "release" then return true end
 
-		mapping = mapping_for(keymap, key)
+		mapping = mapping_for(keymap, key, use_lower)
 		if mapping then
 			keygrabber.stop()
 			mapping[2](args)
@@ -187,7 +194,8 @@ function modalbind.grab(options)
 				modalbind.grab{keymap = keymap,
 					name = name,
 					stay_in_mode = true,
-					args = args}
+					args = args,
+					use_lower=use_lower}
 			else
 				nesting = nesting - 1
 				if nesting < 1 then hide_box() end

--- a/init.lua
+++ b/init.lua
@@ -134,8 +134,10 @@ end
 
 local function mapping_for(keymap, key)
 	for _, mapping in ipairs(keymap) do
-		if mapping[1] == key or
-		(aliases[key] and mapping[1] == aliases[key]) then
+		local m = mapping[1]:lower()
+		local k = key:lower()
+		if m == k or
+		(aliases[k] and m == k) then
 			return mapping
 		end
 	end


### PR DESCRIPTION
1. Add `layout` option to the `grab` function.
Rationale: when two layouts are present in the system, it's often desired for the shortcuts to work regardless of the current chosen language. Currently, `aliases` table may be used to provide char to char mapping, but it is not ideal.
Let's say, for example, I have two layouts, `us` and `ru`. I assign functions to <kbd>.</kbd> (keycode 60) and <kbd>/</kbd> (keycode 61), add aliases <kbd>ю</kbd> (keycode 60) -> <kbd>.</kbd> (keycode 60)  and <kbd>.</kbd> (keycode 61) -> <kbd>/</kbd> (keycode 61). In result I have two keys in two layouts bound to one key.
Alternative approach is to automatically change layout upon entering the input mode (returning to previous one on exit). This way all shortcuts may be defined in one language without additional mapping tables; layout mapping collision is avoided entirely.
Controlling layout by passing the short name of the layout instead of index would be better, but I couldn't find any documentation for the [`xkb_get_group_names`](https://awesomewm.org/doc/api/libraries/awesome.html#xkb_get_group_names) return value syntax.
1. `grab` function now takes 5 arguments, 4 of witch are optional. Passing them as a table would be better.