### PR TITLE
Allow mapping 'close modal' behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ in mpd mode, so that pressing <kbd>n</kbd> several times for skipping a few
 songs is possible. If the parameter is set to false, the mode acts like a menu,
 closing after an action is chosen.
 
+You can configure binding defaults that apply to all modes with modalbind.default_keys
+
+```lua
+ modalbind.default_keys = {
+  {"separator", "mode control" },
+  {"Escape", modalbind.close_box, "Close Modal"},
+  {"Return", modalbind.close_box, "Close Modal"}
+}
+```
+
 ## Installation
 
 Put this repository somewhere in the lua search path for awesome. If your

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ in mpd mode, so that pressing <kbd>n</kbd> several times for skipping a few
 songs is possible. If the parameter is set to false, the mode acts like a menu,
 closing after an action is chosen.
 
-You can configure binding defaults that apply to all modes with modalbind.default_keys
+You can configure binding defaults that apply to all modes with modalbind.default_keys. 
+The default keybindings are Escape and Return as shown.
 
 ```lua
  modalbind.default_keys = {
@@ -79,6 +80,7 @@ You can configure binding defaults that apply to all modes with modalbind.defaul
   {"Return", modalbind.close_box, "Close Modal"}
 }
 ```
+
 
 ## Installation
 

--- a/init.lua
+++ b/init.lua
@@ -173,8 +173,29 @@ modalbind.default_keys = {
   { "Return", modalbind.close_box, "Exit Modal" }
 }
 
+local function merge_default_keys(keymap) 
+  local result = {}
+  for j,k in ipairs(modalbind.default_keys) do
+    local no_add = false
+    for i,m in ipairs(keymap) do 
+      if k[1] ~= "separator" and
+         m[1] == k[1] then 
+        no_add = true
+        break
+      end
+     end
+     if not no_add then
+       table.insert(result, k)
+     end
+  end
+  for _,m in ipairs(keymap) do 
+    table.insert(result, m)
+  end
+  return result
+end
+
 function modalbind.grab(options)
-	local keymap = gears.table.join(modalbind.default_keys or {}, options.keymap or {})
+	local keymap = merge_default_keys(options.keymap or {})
 	local name = options.name
 	local stay_in_mode = options.stay_in_mode or false
 	local args = options.args

--- a/init.lua
+++ b/init.lua
@@ -213,13 +213,13 @@ function modalbind.grab(options)
 		if event == "release" then return true end
 
 		mapping = mapping_for(keymap, key, use_lower)
-    if (mapping[2] == close_box or 
-        mapping[2] == modalbind.close_box) then
-      close_box(keymap, args)
-      return true
-    end
-
 		if mapping then
+      if (mapping[2] == close_box or 
+          mapping[2] == modalbind.close_box) then
+        close_box(keymap, args)
+        return true
+      end
+
 			keygrabber.stop()
 			mapping[2](args)
 			if stay_in_mode then


### PR DESCRIPTION
I moved a few things around so that you can make your own keymapping to close the modal window.

This also defines modalbind.default_keys setting which can be used to create bindings that are mapped on all modals.

I also added 'Return'  as a default mapping for closing the window.
