### PR TITLE
Ensure keys (i.e. "'<>&) are escaped in popup markup

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -103,7 +103,7 @@ local function show_box(s, map, name)
 				label = label .. "\n\n<big>" ..
 					mapping[2] .. "</big>"
 			elseif mapping[1] ~= "onClose" then
-				label = label .. "\n<b>" .. mapping[1] ..
+				label = label .. "\n<b>" .. gears.string.xml_escape(mapping[1]) ..
 					"</b>\t" .. (mapping[3] or "???")
 			end
 		end


### PR DESCRIPTION
Using any of `"'<>&` as a key in the keymap will cause an error to occur in the
logs, and the popup will be a small empty box.  This appears to fix the issue
of using a keymap entry such as:

``` lua
{'<', awesome.restart, 'restart Awesome'}
```