### PR TITLE
Ensure last entry in keymap popup is displayed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -109,6 +109,7 @@ local function show_box(s, map, name)
 		end
 
 	end
+	label = label .. '\n'  -- Ensure last entry is displayed.
 	txt:set_markup(label)
 
 	local x, y = txt:get_preferred_size(s)


### PR DESCRIPTION
The downside is there appears to be a blank line at the bottom of the keymap
popup.  If there is another way to ensure the last line is included in the
popup without adding a blank line, that solution would be ideal.  Because of
this nitpick, I marked this PR as a draft.